### PR TITLE
SFBPopoverWindowFrame subclassing

### DIFF
--- a/SFBPopoverWindow.m
+++ b/SFBPopoverWindow.m
@@ -33,6 +33,7 @@
 
 @interface SFBPopoverWindow (Private)
 - (SFBPopoverWindowFrame *) popoverWindowFrame;
+- (id)windowFrameInstance;
 @end
 
 @implementation SFBPopoverWindow
@@ -91,7 +92,7 @@
 
 	SFBPopoverWindowFrame *popoverWindowFrame = [self popoverWindowFrame];
 	if(nil == popoverWindowFrame) {
-		popoverWindowFrame = [[SFBPopoverWindowFrame alloc] initWithFrame:NSZeroRect];
+        popoverWindowFrame = [[self windowFrameInstance] initWithFrame:NSZeroRect];
 		[super setContentView:[popoverWindowFrame autorelease]];
 	}
 
@@ -485,5 +486,11 @@
 {
 	return (SFBPopoverWindowFrame *)[super contentView];
 }
+
+- (id)windowFrameInstance
+{
+    return [SFBPopoverWindowFrame alloc];
+}
+
 
 @end


### PR DESCRIPTION
Changed SFBPopoverWindow to allow SFBPopoverWindowFrame subclassing.
Added a new method that can be overridden to set the Frame instance in a derived SFBPopoverWindow class. Useful if you need to add some custom drawing to the default methods.