### PR TITLE
fix cyclic-dependency between SFBPopover and CAAnimation leading to l…

### DIFF
--- a/SFBPopover.m
+++ b/SFBPopover.m
@@ -29,6 +29,7 @@
 #import "SFBPopover.h"
 #import "SFBPopoverWindow.h"
 #import "SFBPopoverWindowFrame.h"
+#import "SFBPopoverAnimationDelegate.h"
 
 #include <QuartzCore/QuartzCore.h>
 
@@ -37,6 +38,7 @@
 @private
 	NSViewController * _contentViewController;
 	SFBPopoverWindow * _popoverWindow;
+    SFBPopoverAnimationDelegate* _popoverAnimationDelegate;
 }
 @end
 
@@ -69,8 +71,9 @@
 		[_popoverWindow setContentView:contentView];
 		[_popoverWindow setMinSize:[contentView frame].size];
 
+        _popoverAnimationDelegate = [[SFBPopoverAnimationDelegate alloc] initWithPopoverWindow:_popoverWindow];
 		CAAnimation *animation = [CABasicAnimation animation];
-		[animation setDelegate:self];
+		[animation setDelegate:_popoverAnimationDelegate];
 		[_popoverWindow setAnimations:[NSDictionary dictionaryWithObject:animation forKey:@"alphaValue"]];
 
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidResignKey:) name:NSWindowDidResignKeyNotification object:_popoverWindow];
@@ -406,22 +409,6 @@
 - (void) setResizable:(BOOL)resizable
 {
 	[_popoverWindow setResizable:resizable];
-}
-
-@end
-
-@implementation SFBPopover (NSAnimationDelegateMethods)
-
-- (void) animationDidStop:(CAAnimation *)animation finished:(BOOL)flag 
-{
-#pragma unused(animation)
-	// Detect the end of fade out and close the window
-	if(flag && 0 == [_popoverWindow alphaValue]) {
-		NSWindow *parentWindow = [_popoverWindow parentWindow];
-		[parentWindow removeChildWindow:_popoverWindow];
-		[_popoverWindow orderOut:nil];
-		[_popoverWindow setAlphaValue:1];
-	}
 }
 
 @end

--- a/SFBPopoverAnimationDelegate.h
+++ b/SFBPopoverAnimationDelegate.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2011, 2012, 2013, 2014, 2015 Stephen F. Booth <me@sbooth.org>
+ *  All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class SFBPopoverWindow;
+
+@interface SFBPopoverAnimationDelegate : NSObject
+
+- (instancetype)initWithPopoverWindow:(SFBPopoverWindow*)window;
+
+@end

--- a/SFBPopoverAnimationDelegate.m
+++ b/SFBPopoverAnimationDelegate.m
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2011, 2012, 2013, 2014, 2015 Stephen F. Booth <me@sbooth.org>
+ *  All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFBPopoverAnimationDelegate.h"
+#import "SFBPopoverWindow.h"
+
+@implementation SFBPopoverAnimationDelegate {
+    
+    SFBPopoverWindow* __weak _popoverWindow;
+}
+
+- (instancetype)initWithPopoverWindow:(SFBPopoverWindow*)window {
+    
+    if (self = [super init]) {
+        _popoverWindow = window;
+    }
+    return self;
+}
+
+@end
+
+@implementation SFBPopoverAnimationDelegate (NSAnimationDelegateMethods)
+
+- (void) animationDidStop:(CAAnimation *)animation finished:(BOOL)flag
+{
+#pragma unused(animation)
+    // Detect the end of fade out and close the window
+    if(flag && 0 == [_popoverWindow alphaValue]) {
+        NSWindow *parentWindow = [_popoverWindow parentWindow];
+        [parentWindow removeChildWindow:_popoverWindow];
+        [_popoverWindow orderOut:nil];
+        [_popoverWindow setAlphaValue:1];
+    }
+}
+
+@end


### PR DESCRIPTION
…eaks


Due to CAAnimation retaining its delegate, the following lines from SFBPopover.m:

    CAAnimation *animation = [CABasicAnimation animation];
    [animation setDelegate:self];

would produce a retain cycle, so an instance of SFBPopover would never be deallocated.

Check the leak by allocating two SFBPopovers in a row and assignig to the same local variable: SFBPopover dealloc method is never called.
