### PR TITLE
repair the parent/child relationship when changing the pop over position

### DIFF
--- a/SFBPopovers/SFBPopoverWindow.m
+++ b/SFBPopovers/SFBPopoverWindow.m
@@ -111,6 +111,7 @@
 	NSRect frameRect = [self frame];
 	NSPoint oldOrigin = frameRect.origin;
 	NSPoint oldAttachmentPoint = [[self popoverWindowFrame] attachmentPoint];
+	NSWindow *parentWindow = [self parentWindow];
 
 	CGFloat offset = [[self popoverWindowFrame] arrowHeight] + [[self popoverWindowFrame] distance];
 	switch([[self popoverWindowFrame] popoverPosition]) {
@@ -166,6 +167,7 @@
 	BOOL isKey = [self isKeyWindow];
 	if(isVisible) {
 		NSDisableScreenUpdates();
+		[parentWindow removeChildWindow: self];
 		[self orderOut:self];
 	}
 
@@ -183,6 +185,8 @@
 			[self makeKeyAndOrderFront:self];
 		else
 			[self orderFront:self];
+
+		[parentWindow addChildWindow: self ordered:NSWindowAbove];
 
 		NSEnableScreenUpdates();
 	}


### PR DESCRIPTION
On 10.14.6 at least, ordering out the child window kills the parent/child relationship.

Open the popover, change the position, and move the parent window...

<img width="965" alt="image" src="https://user-images.githubusercontent.com/964904/108569121-54234780-72d9-11eb-80d6-8b2d6eb599c1.png">
